### PR TITLE
Fix two compiler errors

### DIFF
--- a/include/sigmatch/sigmatch.hpp
+++ b/include/sigmatch/sigmatch.hpp
@@ -76,6 +76,7 @@
 #include <span>
 #include <tuple>
 #include <mutex>
+#include <array>
 #include <vector>
 #include <string>
 #include <format>
@@ -950,7 +951,10 @@ namespace impl {
 //
 class msvc_c7599_false_positive_workaround : public std::span<const std::byte>
 {
+public:
     using std::span<const std::byte>::span;
+    
+    msvc_c7599_false_positive_workaround(const std::span<const std::byte>& span) : std::span<const std::byte>(span) {}
 };
 
 } // namespace impl

--- a/include/sigmatch/sigmatch.hpp
+++ b/include/sigmatch/sigmatch.hpp
@@ -938,31 +938,6 @@ private:
     }
 };
 
-///
-/// @cond
-///
-
-namespace impl {
-
-//
-// Inheriting from `std::span` directly will cause MSVC (ver <= v19.29) false positive C7599 error
-//
-// TODO: Remove this class when MSVC releases fixes.
-//
-class msvc_c7599_false_positive_workaround : public std::span<const std::byte>
-{
-public:
-    using std::span<const std::byte>::span;
-    
-    msvc_c7599_false_positive_workaround(const std::span<const std::byte>& span) : std::span<const std::byte>(span) {}
-};
-
-} // namespace impl
-
-///
-/// @endcond
-///
-
 //////////////////////////////////////////////////
 ///
 /// @brief An extended const byte span class
@@ -970,10 +945,20 @@ public:
 /// In contrast to `std::span<const std::byte>`, it can accept pure pointers and `std::span<const
 /// unsigned char>`.
 ///
-class const_byte_span : public impl::msvc_c7599_false_positive_workaround
+class const_byte_span : public std::span<const std::byte>
 {
 public:
-    using impl::msvc_c7599_false_positive_workaround::msvc_c7599_false_positive_workaround;
+    using std::span<const std::byte>::span;
+
+    ///
+    /// @brief Constructor for `std::span<const std::byte>`
+    ///
+    /// @param[in] range A `std::span<const std::byte>` value.
+    ///
+    constexpr const_byte_span(const std::span<const std::byte> &range) noexcept
+        : std::span<const std::byte>{range}
+    {
+    }
 
     ///
     /// @brief Constructor for pure pointer
@@ -982,7 +967,7 @@ public:
     /// @param[in] size  The size of this memory range.
     ///
     constexpr const_byte_span(const void *begin, size_t size) noexcept
-        : impl::msvc_c7599_false_positive_workaround{static_cast<const std::byte *>(begin), size}
+        : std::span<const std::byte>{static_cast<const std::byte *>(begin), size}
     {
     }
 


### PR DESCRIPTION
VS: 17.1.2
MSVC: 19.31.31105

## Missing header \<array\>
![](https://user-images.githubusercontent.com/50246090/169565177-e013a57e-df34-4b20-b235-bfbeeba79c9f.png)
(E2500 is a [false positive error](https://developercommunity.visualstudio.com/t/C20-String-literal-operator-template-u/1318552) from the editor, it doesn't affect the compiler)

Fix:
```cpp
#include <array>
```

## Missing appropriate constructor for msvc_c7599_false_positive_workaround
![](https://user-images.githubusercontent.com/50246090/169571527-77f21e54-8f91-4d84-9ed7-6ea5a1681d42.png)
```
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\xmemory(676,18): error C2672: 'std::construct_at': no matching overloaded function found
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\vector(602): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,std::thread,std::span<const std::byte,18446744073709551615>>(_Alloc &,_Objty *const ,std::thread &&,std::span<const std::byte,18446744073709551615> &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<sigmatch::multi_threaded_searcher::thread_info>,
1>            _Ty=sigmatch::multi_threaded_searcher::thread_info,
1>            _Objty=sigmatch::multi_threaded_searcher::thread_info
1>        ]
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\vector(607): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,std::thread,std::span<const std::byte,18446744073709551615>>(_Alloc &,_Objty *const ,std::thread &&,std::span<const std::byte,18446744073709551615> &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<sigmatch::multi_threaded_searcher::thread_info>,
1>            _Ty=sigmatch::multi_threaded_searcher::thread_info,
1>            _Objty=sigmatch::multi_threaded_searcher::thread_info
1>        ]
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\vector(620): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::_Emplace_back_with_unused_capacity<std::thread,std::span<const std::byte,18446744073709551615>>(std::thread &&,std::span<const std::byte,18446744073709551615> &&)' being compiled
1>        with
1>        [
1>            _Ty=sigmatch::multi_threaded_searcher::thread_info
1>        ]
1>C:\sigmatch\include\sigmatch/sigmatch.hpp(2159): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::emplace_back<std::thread,std::span<const std::byte,18446744073709551615>>(std::thread &&,std::span<const std::byte,18446744073709551615> &&)' being compiled
1>        with
1>        [
1>            _Ty=sigmatch::multi_threaded_searcher::thread_info
1>        ]
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\xmemory(676,18): error C2783: '_Ty *std::construct_at(_Ty *const ,_Types &&...) noexcept(<expr>)': could not deduce template argument for '<unnamed-symbol>'
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\xutility(134): message : see declaration of 'std::construct_at'
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\xmemory(680,47): error C2440: 'initializing': cannot convert from 'initializer list' to 'sigmatch::multi_threaded_searcher::thread_info'
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\xmemory(680,47): message : Invalid aggregate initialization
```

Test code:
![](https://user-images.githubusercontent.com/50246090/169564117-244bb666-c431-49e6-b053-a9c123d46ed4.png)
```
1>C:\sigmatch\include\sigmatch/sigmatch.hpp(2165,1): error C2665: 'sigmatch::impl::msvc_c7599_false_positive_workaround::msvc_c7599_false_positive_workaround': none of the 3 overloads could convert all the argument types
1>C:\sigmatch\include\sigmatch/sigmatch.hpp(955,1): message : could be 'sigmatch::impl::msvc_c7599_false_positive_workaround::msvc_c7599_false_positive_workaround(sigmatch::impl::msvc_c7599_false_positive_workaround &&)'
1>C:\sigmatch\include\sigmatch/sigmatch.hpp(955,1): message : or       'sigmatch::impl::msvc_c7599_false_positive_workaround::msvc_c7599_false_positive_workaround(const sigmatch::impl::msvc_c7599_false_positive_workaround &)'
1>C:\sigmatch\include\sigmatch/sigmatch.hpp(955,1): message : or       'sigmatch::impl::msvc_c7599_false_positive_workaround::msvc_c7599_false_positive_workaround(void)'
1>C:\sigmatch\include\sigmatch/sigmatch.hpp(2165,1): message : or       'sigmatch::impl::msvc_c7599_false_positive_workaround::msvc_c7599_false_positive_workaround<const std::byte,18446744073709551615>(const std::span<const std::byte,18446744073709551615> &)', which inherits 'std::span<const std::byte,18446744073709551615>::span(const std::span<_OtherTy,_OtherExtent> &) noexcept' via base class 'std::span<const std::byte,18446744073709551615>'
1>C:\sigmatch\include\sigmatch/sigmatch.hpp(2165,1): message : while trying to match the argument list '(std::span<const std::byte,18446744073709551615>)'
```
I'm not sure whether this is a bug of MSVC, but there is no harm to add a constructor to fix it:
```cpp
class msvc_c7599_false_positive_workaround : public std::span<const std::byte>
{
public:
    using std::span<const std::byte>::span;
    
    msvc_c7599_false_positive_workaround(const std::span<const std::byte>& span) : std::span<const std::byte>(span) {}
};
```